### PR TITLE
Fix sensor setup and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ This Home Assistant integration retrieves outage information from the Tauron Dys
 4. **Nr mieszkania** (Flat number, optional): Enter flat number if applicable.
 
 Once entered, the system will provide outage information for your location.
+
+### Troubleshooting
+
+If Home Assistant reports an error about `async_forward_entry_setup`,
+update the integration to the latest version. This release uses the
+`async_forward_entry_setups` API introduced in recent Home Assistant
+versions to forward your configuration to the sensor platform.

--- a/custom_components/tauron_dystrybucja/__init__.py
+++ b/custom_components/tauron_dystrybucja/__init__.py
@@ -3,7 +3,8 @@ import logging
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers import discovery
+
+PLATFORMS = ["sensor"]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,6 +18,14 @@ async def async_setup(hass: HomeAssistant, config: dict):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Tauron Dystrybucja from a config entry."""
     _LOGGER.debug("Setting up Tauron Dystrybucja config entry.")
-    hass.data[DOMAIN] = entry.data
-    # Discover the entities based on the config entry
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/tauron_dystrybucja/sensors.py
+++ b/custom_components/tauron_dystrybucja/sensors.py
@@ -1,7 +1,10 @@
 import logging
+from datetime import datetime, timedelta
+
 import requests
 from homeassistant.helpers.entity import Entity
-from datetime import datetime, timedelta
+
+from . import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 class TauronOutageSensor(Entity):
     """Representation of a Tauron outage sensor."""
@@ -38,3 +41,17 @@ class TauronOutageSensor(Entity):
                 self._last_update = now
             else:
                 _LOGGER.error("Failed to fetch outage data")
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Tauron outage sensor from a config entry."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    sensor = TauronOutageSensor(
+        "Tauron Outage",
+        data.get("city"),
+        data.get("street"),
+        data.get("house_number"),
+        data.get("flat_number"),
+        update_interval=30,
+    )
+    async_add_entities([sensor], True)


### PR DESCRIPTION
## Summary
- use `async_forward_entry_setups` and add unload logic
- expose sensor setup via `async_setup_entry`
- document troubleshooting for config entry setup errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567fc5c6048330810fe1caa806b316